### PR TITLE
Add base_directory configuration option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,8 @@ author: 'James Sulinski'
 branding:
   icon: 'heart'
   color: 'gray-dark'
-inputs: 
-  active_scanners: 
+inputs:
+  active_scanners:
     description: 'Active scanners'
     required: false
     default: 'all'
@@ -30,6 +30,10 @@ inputs:
     description: 'Location of the configuration file, if not default'
     required: false
     default: 'file://../salus-configuration.yaml'
+  base_directory:
+    description: 'An optional path (from the repository root) to scan within'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,6 @@ custom_info:
 reports:
   - uri: $INPUT_REPORT_URI
     format: $INPUT_REPORT_FORMAT
-    verbose: $INPUT_REPORT_VERBOSITY" | tee $GITHUB_WORKSPACE/../salus-configuration.yaml 
+    verbose: $INPUT_REPORT_VERBOSITY" | tee "$GITHUB_WORKSPACE/../salus-configuration.yaml"
 
-cd /home && BUNDLE_GEMFILE=/home/Gemfile bundle exec /home/bin/salus scan --repo_path "$GITHUB_WORKSPACE" --config "$INPUT_SALUS_CONFIGURATION"
+cd /home && BUNDLE_GEMFILE=/home/Gemfile bundle exec /home/bin/salus scan --repo_path "$GITHUB_WORKSPACE/$INPUT_BASE_DIRECTORY" --config "$INPUT_SALUS_CONFIGURATION"


### PR DESCRIPTION
This PR adds a `base_directory` configuration option to allow modifying the `--repo_path` flag that gets sent to Salus. This is useful for monorepos that wish to have multiple salus configurations and run them independently.